### PR TITLE
Group variable is not used when skeleton paths are created

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a ch
 
 
 ## [Unreleased](https://github.com/idealista/prometheus_jmx_exporter-role/tree/develop)
+### Fixed
+- *[#26](https://github.com/idealista/prometheus_jmx_exporter-role/issues/26) Group variable is not used when skeleton paths are created* @sorobon
 
 ## [1.5.0](https://github.com/idealista/prometheus_jmx_exporter-role/tree/1.5.0)
 [Full Changelog](https://github.com/idealista/prometheus_jmx_exporter-role/compare/1.4.0...1.5.0)

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -18,7 +18,7 @@
   file:
     dest: "{{ item }}"
     owner: "{{ jmx_exporter_user }}"
-    group: "{{ jmx_exporter_user }}"
+    group: "{{ jmx_exporter_group }}"
     state: directory
   with_items:
     - "{{ jmx_exporter_root_directory }}"


### PR DESCRIPTION
### Description

Skeleton paths group are using user variable name instead of group variable name

**Expected behavior:** Should use group name variable

**Actual behavior:** Uses user name variable

**Reproduces how often:** 100%

### Versions

All

### Additional Information

https://github.com/idealista/prometheus_jmx_exporter-role/blob/master/tasks/install.yml#L21