### PR TITLE
Fix initial service startup - idealista/prometheus_jmx_exporter-role#40:

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -27,6 +27,9 @@ jmx_exporter_log_directory: /var/log/jmx_exporter
 jmx_exporter_log_file: "jmx_exporter.log"
 jmx_exporter_log_path: "{{ jmx_exporter_log_directory }}/{{ jmx_exporter_log_file }}"
 
+jmx_exporter_run_directory: /run/jmx_exporter
+jmx_exporter_run_pidfile: "{{ jmx_exporter_run_directory }}/jmx_exporter.pid"
+
 jmx_exporter_classpath_entries: []
 #  - jar_path_1
 #  - jar_path_2

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -24,6 +24,7 @@
     - "{{ jmx_exporter_root_directory }}"
     - "{{ jmx_exporter_conf_directory }}"
     - "{{ jmx_exporter_log_directory }}"
+    - "{{ jmx_exporter_run_directory }}"
 
 - name: JMX_EXPORTER | Download binary
   get_url:

--- a/templates/jmx_exporter.service.j2
+++ b/templates/jmx_exporter.service.j2
@@ -24,10 +24,10 @@ ExecStart=/bin/sh -c "/usr/bin/java $JAVA_OPTS $JAVA_MEM \
                       -cp {{ ([jmx_exporter_jar_path] + jmx_exporter_classpath_entries)|join(":") }} {{ jmx_exporter_main_class }} \
                       {{ jmx_exporter_port }} {{ jmx_exporter_conf_path }} \
                       > {{ jmx_exporter_log_path }} 2>&1"
-ExecStartPost=/bin/sh -c "echo $MAINPID > /run/jmx_exporter/jmx_exporter.pid"
+ExecStartPost=/bin/sh -c "echo $MAINPID > {{ jmx_exporter_run_pidfile }}"
 ExecReload=/bin/kill -HUP $MAINPID
 WorkingDirectory={{ jmx_exporter_root_directory }}
-PIDFile=/run/jmx_exporter/jmx_exporter.pid
+PIDFile={{ jmx_exporter_run_pidfile }}
 KillSignal=SIGTERM
 SuccessExitStatus=143
 


### PR DESCRIPTION
* create directory for PID file
### Description of the Change

Service can't start without directory for pidfile. In this MR, I added creating of the directory


### Benefits

Fixing issue. PID file can be in another location now.

### Possible Drawbacks

No drawbacks

### Applicable Issues

#40
